### PR TITLE
Use Orcid IDs instead of email adresses

### DIFF
--- a/root.tex
+++ b/root.tex
@@ -80,7 +80,7 @@
 
 \author{
     Piotr Spieker \orcidlink{0000-0002-0449-3741} $^{1*}$,
-    Nick Le Large$^{2*}$ and
+    Nick Le Large \orcidlink{0009-0006-5191-9043} $^{2*}$ and
     Martin Lauer \orcidlink{0000-0003-4414-5722} $^{2}$% <-this % stops a space
     \thanks{
         $^{1}$Piotr Spieker, né Orzechowski, is with dotscene GmbH, Freiburg, Germany
@@ -88,10 +88,9 @@
     \thanks{
         $^{2}$Nick Le Large and Martin Lauer are with the Institute of Measurement and Control Systems, Karlsruhe Institute of Technology (KIT),
         Karlsruhe, Germany
-        {\tt\small \{nick.lelarge, martin.lauer\}@kit.edu}
     }
     \thanks{
-        $^{*}$Authors contributed equally to this work.
+        $^{*}$Authors contributed equally to this work
     }
 }
 % use for special paper notices


### PR DESCRIPTION
Open tasks
- [x] @ll-nick get an ORCID ID and add it to `root.tex` as well
- [x] Remove Martins and Nicks email addresses from the footer

Closes #27 