### PR TITLE
Add copyright statement

### DIFF
--- a/root.tex
+++ b/root.tex
@@ -92,7 +92,7 @@
 \usepackage[shortcuts]{extdash}
 
 % Copyright box for arxiv upload
-\usepackage[absolute,showboxes]{textpos}
+\usepackage[absolute]{textpos}
 \usepackage{setspace}
 \setlength{\TPHorizModule}{\paperwidth}
 \setlength{\TPVertModule}{\paperheight}


### PR DESCRIPTION
This adds a copyright statement which is required for an upload to arxiv. 
I prepared the copyright statement for a re-upload should the paper get accepted, too.

Right now, it looks like this:

![copyright_statement](https://github.com/user-attachments/assets/f996c66f-f6ff-4759-a2fe-2031c0fca640)
