### PR TITLE
Remove arxiv zip

### DIFF
--- a/arxiv.zip
+++ b/arxiv.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8bb5a05eb59238fad74889d45e857200dd3677277a685cc87bdfdaa832bc192d
-size 752651


### PR DESCRIPTION
cb68c532aa6dca1ca323e03913d69d9a29104e69 moves the arxiv zip out of the root directory to de-clutter it a little bit.

20c3c96384d92add2b241d194c7c96fc5a9359d7 updates the arxiv.zip to contain the 2nd submission which contains #52 and #53