### PR TITLE
Add conference materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ while maintaining system safety by clearly and precisely defining the conditions
 The proposed method is implemented as a ready to use header-only C++ library, published under the MIT License.
 Together with the Pac-Man demo, it is available at 
 [github.com/KIT-MRT/arbitration_graphs](https://github.com/KIT-MRT/arbitration_graphs).
+
+---
+
+<sup>
+© 2025 IEEE.
+Personal use of this material is permitted.
+Permission from IEEE must be obtained for all other uses, in any current or future media,
+including reprinting/republishing this material for advertising or promotional purposes,
+creating new collective works, for resale or redistribution to servers or lists,
+or reuse of any copyrighted component of this work in other works.
+</sup>

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Piotr Spieker [<sup><img src="supp_material/ORCID-iD_icon.svg" height="14"/></su
 Nick Le Large [<sup><img src="supp_material/ORCID-iD_icon.svg" height="14"/></sup>](https://orcid.org/0009-0006-5191-9043) and
 Martin Lauer [<sup><img src="supp_material/ORCID-iD_icon.svg" height="14"/></sup>](https://orcid.org/0000-0003-4414-5722)
 
-Presented at 2025 IEEE International Conference on Systems, Man, and Cybernetics (SMC)  
+Presented at 2025 IEEE International Conference on Systems, Man, and Cybernetics (SMC).  
 October 5-8, Vienna, Austria  
+
+Find the accompanying presentation slides [here](supp_material/2025-smc-presentation.pdf).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Martin Lauer [<sup><img src="supp_material/ORCID-iD_icon.svg" height="14"/></sup
 Presented at 2025 IEEE International Conference on Systems, Man, and Cybernetics (SMC)  
 October 5-8, Vienna, Austria  
 
+---
+
+![Arbitration Graph with Safety Extensions](supp_material/visual_abstract_poster.svg)
+
 ## Abstract
 
 This paper introduces an extension to the 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Piotr Spieker [<sup><img src="supp_material/ORCID-iD_icon.svg" height="14"/></su
 Nick Le Large [<sup><img src="supp_material/ORCID-iD_icon.svg" height="14"/></sup>](https://orcid.org/0009-0006-5191-9043) and
 Martin Lauer [<sup><img src="supp_material/ORCID-iD_icon.svg" height="14"/></sup>](https://orcid.org/0000-0003-4414-5722)
 
-2025 IEEE Intelligent Vehicles Symposium, June 22-25, Cluj-Napoca, Romania *(in review)*
+Presented at 2025 IEEE International Conference on Systems, Man, and Cybernetics (SMC)  
+October 5-8, Vienna, Austria  
 
 ## Abstract
 

--- a/supp_material/2025-smc-presentation.pdf
+++ b/supp_material/2025-smc-presentation.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89d5fe283db3dac4eaaca1f726c6dda98418da82f6d0f9dc8856cfd97d5d7785
+size 4441709

--- a/supp_material/visual_abstract_poster.svg
+++ b/supp_material/visual_abstract_poster.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8341b93cd090cf34dd246a621f4335e40fee4e018d99faf7e66366d5ed82bf81
+size 1969626


### PR DESCRIPTION
This adds the following things to the Readme:
- Fix the conference name, date and place (we were still referring to the IV)
- Add the visual abstract
- Link to the presentation slides
- Add a copyright notice, since the IEEE now holds the copyright to this work